### PR TITLE
Show help if command is unknown

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -32,6 +32,12 @@ module.exports = function createBapBin (bapConfig) {
     .option('-l, --limit <n>', 'Limit how many releases to display per branch', parseInt, 10)
     .action(make('list'))
 
+  program
+    .command('*')
+    .action(function () {
+      program.outputHelp()
+    })
+
   program.parse(process.argv)
 
   if (!process.argv.slice(2).length) {


### PR DESCRIPTION
I kept typing `bap deploy` like a moron and was wondering why nothing happened. This change makes it output the help info if it doesn't recognise the command.
