### PR TITLE
Use promises instead of generators

### DIFF
--- a/lib/cached.js
+++ b/lib/cached.js
@@ -8,7 +8,7 @@ module.exports = function cached (namespace, producer, timeout) {
   CACHE[namespace] = {}
   var cache = CACHE[namespace]
 
-  return co(function * () {
+  return function () {
     var args = Array.prototype.slice.call(arguments)
     var key = args.join(SEPARATOR)
 
@@ -46,5 +46,5 @@ module.exports = function cached (namespace, producer, timeout) {
     }
 
     return cloneDeep(cache[key].val) || cache[key].fetch
-  })
+  }
 }

--- a/lib/getCurrent.js
+++ b/lib/getCurrent.js
@@ -1,6 +1,7 @@
 var co = require('creed').coroutine
 
-module.exports = co(function * getCurrent (s3, branch) {
-  var current = yield s3.tryReadingFile(`/${branch}/current`)
-  return current ? current.Body.toString() : null
-})
+module.exports = function getCurrent (s3, branch) {
+  return s3.tryReadingFile(`/${branch}/current`).then(function (current) {
+    return current ? current.Body.toString() : null
+  })
+}

--- a/lib/s3.js
+++ b/lib/s3.js
@@ -12,15 +12,13 @@ S3FS.prototype.readdir = function () {
 
 // extend S3FS with a function that attempts reading the file, but
 // handles not found case without throwing
-S3FS.prototype.tryReadingFile = co(function * tryReadFile (path) {
-  try {
-    return yield this.readFile(path)
-  } catch (err) {
+S3FS.prototype.tryReadingFile = function tryReadFile (path) {
+  return this.readFile(path).catch(function (err) {
     if (err.code !== 'NoSuchKey') {
       throw err
     }
-  }
-})
+  })
+}
 
 module.exports = function (bapConfig) {
   return new S3FS(bapConfig.bucket, {


### PR DESCRIPTION
@KidkArolis i don't know why this fixes it (i.e. i dont know what is wrong with the generator setup) but it does. Without each of these changes, shelly is unable to catch exceptions being thrown out of s3fs/aws-sdk; they end up getting emitted as unhandled rejections.

This is one of the things stopping us having better DX with shelly when developing both new apps that have never been released and when working offline.